### PR TITLE
Fill all requirements for releasing and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,53 @@
 # ⚠️ Work in progress
 
 ## Do not use in production!
+
+
+## Releasing
+
+We're using Sonatype OSSRH to host our open source project binaries.
+Docs: https://central.sonatype.org/publish/publish-guide/
+
+#### 1. Get access to be able to deploy
+
+1. First create an account to access JIRA and later the repository manager https://issues.sonatype.org/secure/Signup!default.jspa
+2. Create a ticket similar to https://issues.sonatype.org/browse/OSSRH-59076 & get one of the people who already have access to comment on the request with approval (you can ask in #team-platform channel).
+
+#### 2. Prepare your local setup
+
+1. Create an Access User Token here: https://oss.sonatype.org/#profile;User%20Token (same login as for JIRA) we will need it for the settings file below.
+2. Create a gpg key and distribute your public key, see docs here: https://central.sonatype.org/publish/requirements/gpg/ (we will need the passphase to be specified in the settings file below).
+3. Create a `~/.m2/settings.xml` file with this content (replace the capitalized terms)
+```
+<settings>
+  <servers>
+    <server>
+      <id>ossrh</id>
+      <username>ACCESS_USER_TOKEN_USERNAME</username>
+      <password>ACCESS_USER_TOKEN_PASS</password>
+    </server>
+  </servers>
+  <profiles>
+    <profile>
+      <id>ossrh</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <gpg.executable>gpg</gpg.executable>
+        <gpg.passphrase>GPG_PASSPHASE</gpg.passphrase>
+      </properties>
+    </profile>
+  </profiles>
+</settings>
+```
+
+#### 3. Deploy
+
+1. Change the version in `posthog/pom.xml` accordingly (latest versions can be found here: https://search.maven.org/search?q=com.posthog.java)
+2. Run `mvn deploy` in `posthog-java/posthog` folder.
+
+#### 4. Close and release
+
+1. In https://oss.sonatype.org/#stagingRepositories you should see your just pushed files. Click "Close" and check the activity tab to make sure all validations passed (wait and refresh).
+2. After all validations passed the Release button will become available to publish the new version.

--- a/posthog/pom.xml
+++ b/posthog/pom.xml
@@ -55,23 +55,19 @@
 </dependency>
   </dependencies>
 
+<distributionManagement>
+  <snapshotRepository>
+    <id>ossrh</id>
+    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+  </snapshotRepository>
+  <repository>
+    <id>ossrh</id>
+    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+  </repository>
+</distributionManagement>
+
   <build>
-    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
       <plugins>
-        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
-        <plugin>
-          <artifactId>maven-clean-plugin</artifactId>
-          <version>3.1.0</version>
-        </plugin>
-        <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
-        <plugin>
-          <artifactId>maven-resources-plugin</artifactId>
-          <version>3.0.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
-        </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.22.1</version>
@@ -80,27 +76,57 @@
           </configuration>
         </plugin>
         <plugin>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>3.0.2</version>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.2.1</version>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+              <goals>
+                <goal>jar-no-fork</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
-          <artifactId>maven-install-plugin</artifactId>
-          <version>2.5.2</version>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.3.1</version>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.8.2</version>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>3.0.1</version>
+          <executions>
+            <execution>
+              <id>sign-artifacts</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>sign</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.5.3</version>
+          <configuration>
+            <autoVersionSubmodules>true</autoVersionSubmodules>
+            <useReleaseProfile>false</useReleaseProfile>
+            <releaseProfiles>release</releaseProfiles>
+            <goals>deploy</goals>
+          </configuration>
         </plugin>
         <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
-        <plugin>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>3.7.1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.0.0</version>
-        </plugin>
       </plugins>
-    </pluginManagement>
   </build>
 </project>


### PR DESCRIPTION
Added javadocs, sources & signing (removed `pluginManagement` those 3 things happen properly, that worked & I didn't bother to figure out how to make it work with `pluginManagement`).

I documented how someone can release as well because it's annoyingly complicated. We'll potentially want to create github actions for this, but that's lower priority for now.
<img width="343" alt="Screen Shot 2021-10-05 at 04 22 27" src="https://user-images.githubusercontent.com/890921/135950323-24eabf6a-6435-49b9-a886-ca9669c5aa20.png">


