### PR TITLE
Update queuemanager default conf

### DIFF
--- a/posthog/src/main/java/com/posthog/java/QueueManager.java
+++ b/posthog/src/main/java/com/posthog/java/QueueManager.java
@@ -54,8 +54,8 @@ public class QueueManager implements Runnable {
         private final Sender sender;
 
         // optional
-        private int maxQueueSize = 10; // if more than this many items in queue trigger a send
-        private Duration maxTimeInQueue = Duration.ofSeconds(5); // if more than this time in queue send trigger a send
+        private int maxQueueSize = 50; // if more than this many items in queue trigger a send
+        private Duration maxTimeInQueue = Duration.ofSeconds(1); // if more than this time in queue send trigger a send
         private int sleepMs = 100; // how long do we sleep between checking the above conditions
 
         public Builder(Sender sender) {


### PR DESCRIPTION
As discussed in slack bumping to 50 items in queue (less probable DDoS) & down to 1s time (so we are less likely losing events)