### PR TITLE
Must always close OkHTTP connections

### DIFF
--- a/posthog/src/main/java/com/posthog/java/HttpSender.java
+++ b/posthog/src/main/java/com/posthog/java/HttpSender.java
@@ -54,9 +54,16 @@ public class HttpSender implements Sender {
             RequestBody body = RequestBody.create(json, JSON);
             Request request = new Request.Builder().url(host + "/batch").post(body).build();
             Call call = client.newCall(request);
-            call.execute();
+
+            // must always close an OkHTTP response
+            // https://square.github.io/okhttp/4.x/okhttp/okhttp3/-call/execute/
+            Response response = client.newCall(request).execute();
         } catch (Exception e) {
             e.printStackTrace();
+        } finally {
+            if (response != null) {
+                response.close();
+            }
         }
     }
 

--- a/posthog/src/main/java/com/posthog/java/HttpSender.java
+++ b/posthog/src/main/java/com/posthog/java/HttpSender.java
@@ -50,6 +50,7 @@ public class HttpSender implements Sender {
         }
         String json = getRequestBody(events);
 
+        Response response = null;
         try {
             MediaType JSON = MediaType.parse("application/json; charset=utf-8");
             RequestBody body = RequestBody.create(json, JSON);
@@ -58,7 +59,7 @@ public class HttpSender implements Sender {
 
             // must always close an OkHTTP response
             // https://square.github.io/okhttp/4.x/okhttp/okhttp3/-call/execute/
-            Response response = client.newCall(request).execute();
+            response = client.newCall(request).execute();
         } catch (Exception e) {
             e.printStackTrace();
         } finally {

--- a/posthog/src/main/java/com/posthog/java/HttpSender.java
+++ b/posthog/src/main/java/com/posthog/java/HttpSender.java
@@ -10,6 +10,7 @@ import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
+import okhttp3.Response;
 
 public class HttpSender implements Sender {
     private String apiKey;


### PR DESCRIPTION
[In this conversation](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1643968896801409) a user reports log errors when using PostHog Java SDK in Spring Boot

```
A connection to <url to our Posthog server> was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);
```

We only use OkHTTP in one place. And don't explicitly close the response body.

[OK HTTP Docs say](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-call/execute/)...

> To avoid leaking resources callers must [close the response body](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-response-body/) or the response.

This change captures the response and ensures that if it is present after the try-catch block that it is closed