### PR TITLE
Shaded all transitive dependencies

### DIFF
--- a/posthog/pom.xml
+++ b/posthog/pom.xml
@@ -120,20 +120,20 @@
             </execution>
           </executions>
         </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-gpg-plugin</artifactId>
-          <version>3.0.1</version>
-          <executions>
-            <execution>
-              <id>sign-artifacts</id>
-              <phase>verify</phase>
-              <goals>
-                <goal>sign</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
+<!--        <plugin>-->
+<!--          <groupId>org.apache.maven.plugins</groupId>-->
+<!--          <artifactId>maven-gpg-plugin</artifactId>-->
+<!--          <version>3.0.1</version>-->
+<!--          <executions>-->
+<!--            <execution>-->
+<!--              <id>sign-artifacts</id>-->
+<!--              <phase>verify</phase>-->
+<!--              <goals>-->
+<!--                <goal>sign</goal>-->
+<!--              </goals>-->
+<!--            </execution>-->
+<!--          </executions>-->
+<!--        </plugin>-->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
@@ -146,6 +146,47 @@
           </configuration>
         </plugin>
         <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>3.3.0</version>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>shade</goal>
+              </goals>
+              <configuration>
+                <relocations>
+                  <relocation>
+                    <pattern>okhttp3</pattern>
+                    <shadedPattern>com.posthog.java.shaded.okhttp3</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>kotlin</pattern>
+                    <shadedPattern>com.posthog.java.shaded.kotlin</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>okio</pattern>
+                    <shadedPattern>com.posthog.java.shaded.okio</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>org.intellij.lang</pattern>
+                    <shadedPattern>com.posthog.java.shaded.org.intellij.lang</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>org.json</pattern>
+                    <shadedPattern>com.posthog.java.shaded.org.json</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>org.jetbrains</pattern>
+                    <shadedPattern>com.posthog.java.shaded.org.jetbrains</shadedPattern>
+                  </relocation>
+                </relocations>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
   </build>
 </project>

--- a/posthog/pom.xml
+++ b/posthog/pom.xml
@@ -120,20 +120,20 @@
             </execution>
           </executions>
         </plugin>
-<!--        <plugin>-->
-<!--          <groupId>org.apache.maven.plugins</groupId>-->
-<!--          <artifactId>maven-gpg-plugin</artifactId>-->
-<!--          <version>3.0.1</version>-->
-<!--          <executions>-->
-<!--            <execution>-->
-<!--              <id>sign-artifacts</id>-->
-<!--              <phase>verify</phase>-->
-<!--              <goals>-->
-<!--                <goal>sign</goal>-->
-<!--              </goals>-->
-<!--            </execution>-->
-<!--          </executions>-->
-<!--        </plugin>-->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>3.0.1</version>
+          <executions>
+            <execution>
+              <id>sign-artifacts</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>sign</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>

--- a/posthog/src/test/java/com/posthog/java/PostHogTest.java
+++ b/posthog/src/test/java/com/posthog/java/PostHogTest.java
@@ -218,7 +218,7 @@ public class PostHogTest {
         updateInstantNow(secondInstant);
         ph.capture("id2", "first batch event");
         updateInstantNow(thirdInstant);
-        waitUntilQueueEmpty(queueManager, 10000);
+        waitUntilQueueEmpty(queueManager, 15000);
         ph.capture("id6", "second batch event");
         ph.shutdown();
         assertEquals(2, sender.calls.size());


### PR DESCRIPTION
# Why ?
In issue #22 I mentioned that it would be great to have transitive dependencies shaded.
The reason behind this is that posthog is an add-on and shouldn't influence the dependencies in an application which simply wants to use posthog.
Currently using posthog brings in several tranitive deps which we have been using in different versions in our projects.

# What ?
To avoid dependency clashes I used the Maven-Shade-Plugin.
This moves all transitive deps into a dedicated package (com.postman.shaded) and puts them into a Uber-jar.
This DOESN'T influence how you are working with the project since this happens as part of the packaging phase so the changed packages are only ever visible when pulling the resulting jar.

