### PR TITLE
Added CVE-checks and dependency verification

### DIFF
--- a/posthog/pom.xml
+++ b/posthog/pom.xml
@@ -63,12 +63,12 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>4.9.1</version>
+      <version>4.10.0</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
-      <version>4.9.1</version>
+      <version>4.10.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -130,6 +130,32 @@
               <phase>verify</phase>
               <goals>
                 <goal>sign</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.owasp</groupId>
+          <artifactId>dependency-check-maven</artifactId>
+          <version>7.2.1</version>
+          <configuration>
+            <failBuildOnCVSS>7</failBuildOnCVSS>
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.simplify4u.plugins</groupId>
+          <artifactId>pgpverify-maven-plugin</artifactId>
+          <executions>
+            <execution>
+              <goals>
+                <goal>check</goal>
               </goals>
             </execution>
           </executions>


### PR DESCRIPTION
# Why ?
Currently dependencies are not checked for CVEs and correct signing.
Lack of CVE-scanning results in old libs making Posthog less secure.
Lack of verification can allow the injection of hijacked dependencies (a.k.a supply chain attack)

# What ?
Added OWASP-plugin to check for CVEs. Build will break on a CVE of HIGH or above.

Added signature-check plugin to erify the signature of the jars with their key.
Build breaks if these don't match.