### PR TITLE
chore: add retry logic

### DIFF
--- a/posthog/src/main/java/com/posthog/java/HttpSender.java
+++ b/posthog/src/main/java/com/posthog/java/HttpSender.java
@@ -129,10 +129,9 @@ public class HttpSender implements Sender {
                     + retryInterval + "ms before retrying.");
 
             try {
-                // TODO: use the Retry-After header if present to determine the
-                // retry interval.
-                // For now we use a fixed initial retry interval, falling back
-                // exponentially.
+                // TODO: use the Retry-After header if present to determine the retry interval.
+                // For now we use a fixed initial retry interval, falling back exponentially.
+                // TODO this is a blocking sleep, we should use `Future`s here instead
                 Thread.sleep(retryInterval);
             } catch (Exception e) {
                 e.printStackTrace();

--- a/posthog/src/main/java/com/posthog/java/HttpSender.java
+++ b/posthog/src/main/java/com/posthog/java/HttpSender.java
@@ -111,8 +111,7 @@ public class HttpSender implements Sender {
             }
 
             retries += 1;
-            
-            
+
             if (retries > maxRetries) {
                 // Make sure to shout very loudly if we have reached the end of
                 // our retries and haven't managed to send events.
@@ -120,7 +119,7 @@ public class HttpSender implements Sender {
                 return false;
             }
 
-            long retryInterval = initialRetryInterval.toMillis() * (long) Math.pow(3, retries)
+            long retryInterval = initialRetryInterval.toMillis() * (long) Math.pow(3, retries);
 
             // On retries, make sure we log the response code or exception such
             // that people will know if something is up, ensuring we include the

--- a/posthog/src/main/java/com/posthog/java/HttpSender.java
+++ b/posthog/src/main/java/com/posthog/java/HttpSender.java
@@ -74,9 +74,10 @@ public class HttpSender implements Sender {
         Response response = null;
         int retries = 0;
 
+        MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+        RequestBody body = RequestBody.create(json, JSON);
+
         while (true) {
-            MediaType JSON = MediaType.parse("application/json; charset=utf-8");
-            RequestBody body = RequestBody.create(json, JSON);
             Request request = new Request.Builder().url(host + "/batch").post(body).build();
             Call call = client.newCall(request);
 
@@ -89,7 +90,7 @@ public class HttpSender implements Sender {
                     return true;
                 }
 
-                // On 4xx status codes, the request was unsuccessful so we
+                // On 4xx status codes, the request was unsuccessful, so we
                 // return and assume events have not been ingested by PostHog.
                 if (response.code() >= 400 && response.code() < 500) {
                     // Make sure we log that we are giving up specifically

--- a/posthog/src/main/java/com/posthog/java/PostHog.java
+++ b/posthog/src/main/java/com/posthog/java/PostHog.java
@@ -182,7 +182,7 @@ public class PostHog {
         try {
             // Ensure that we generate an identifier for this event such that we can e.g.
             // deduplicate server-side any duplicates we may receive.
-            eventJson.put("messageId", UUID.randomUUID().toString());
+            eventJson.put("uuid", UUID.randomUUID().toString());
             eventJson.put("timestamp", Instant.now().toString());
             eventJson.put("distinct_id", distinctId);
             eventJson.put("event", event);

--- a/posthog/src/main/java/com/posthog/java/PostHog.java
+++ b/posthog/src/main/java/com/posthog/java/PostHog.java
@@ -182,7 +182,7 @@ public class PostHog {
         try {
             // Ensure that we generate an identifier for this event such that we can e.g.
             // deduplicate server-side any duplicates we may receive.
-            eventJson.put("uuid", UUID.randomUUID().toString());
+            eventJson.put("messageId", UUID.randomUUID().toString());
             eventJson.put("timestamp", Instant.now().toString());
             eventJson.put("distinct_id", distinctId);
             eventJson.put("event", event);

--- a/posthog/src/main/java/com/posthog/java/PostHog.java
+++ b/posthog/src/main/java/com/posthog/java/PostHog.java
@@ -3,6 +3,7 @@ package com.posthog.java;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -179,6 +180,9 @@ public class PostHog {
     private JSONObject getEventJson(String event, String distinctId, Map<String, Object> properties) {
         JSONObject eventJson = new JSONObject();
         try {
+            // Ensure that we generate an identifier for this event such that we can e.g.
+            // deduplicate server-side any duplicates we may receive.
+            eventJson.put("uuid", UUID.randomUUID().toString());
             eventJson.put("timestamp", Instant.now().toString());
             eventJson.put("distinct_id", distinctId);
             eventJson.put("event", event);

--- a/posthog/src/main/java/com/posthog/java/Sender.java
+++ b/posthog/src/main/java/com/posthog/java/Sender.java
@@ -5,5 +5,5 @@ import java.util.List;
 import org.json.JSONObject;
 
 public interface Sender {
-    public void send(List<JSONObject> events);
+    public Boolean send(List<JSONObject> events);
 }

--- a/posthog/src/test/java/com/posthog/java/PostHogTest.java
+++ b/posthog/src/test/java/com/posthog/java/PostHogTest.java
@@ -75,11 +75,11 @@ public class PostHogTest {
         assertEquals(1, sender.calls.size());
         assertEquals(2, sender.calls.get(0).size());
 
-        String uuid = sender.calls.get(0).get(0).getString("messageId");
+        String uuid = sender.calls.get(0).get(0).getString("uuid");
         assertEquals(36, uuid.toString().length());
 
         // Make sure subsequent calls generate a different UUID
-        String secondUuid = sender.calls.get(0).get(1).getString("messageId");
+        String secondUuid = sender.calls.get(0).get(1).getString("uuid");
         assertNotEquals(uuid.toString(), secondUuid.toString());
     }
 

--- a/posthog/src/test/java/com/posthog/java/PostHogTest.java
+++ b/posthog/src/test/java/com/posthog/java/PostHogTest.java
@@ -75,11 +75,11 @@ public class PostHogTest {
         assertEquals(1, sender.calls.size());
         assertEquals(2, sender.calls.get(0).size());
 
-        String uuid = sender.calls.get(0).get(0).getString("uuid");
+        String uuid = sender.calls.get(0).get(0).getString("messageId");
         assertEquals(36, uuid.toString().length());
 
         // Make sure subsequent calls generate a different UUID
-        String secondUuid = sender.calls.get(0).get(1).getString("uuid");
+        String secondUuid = sender.calls.get(0).get(1).getString("messageId");
         assertNotEquals(uuid.toString(), secondUuid.toString());
     }
 

--- a/posthog/src/test/java/com/posthog/java/TestSender.java
+++ b/posthog/src/test/java/com/posthog/java/TestSender.java
@@ -12,7 +12,8 @@ public class TestSender implements Sender {
     TestSender() {
     }
 
-    public void send(List<JSONObject> events) {
+    public Boolean send(List<JSONObject> events) {
         calls.add(events);
+        return true;
     }
 }


### PR DESCRIPTION
Previously we were not retrying, now we do.

We by default perform 3 retries, starting with a 500 ms delay, then 1500 ms delay, then 4500 ms delay, finally a 13500 ms delay.

It is important the, given we are handling retries, we provide client side identifiers to ensure we can remove duplicates. In this case it is the uuid attribute of the events.

The original PR was https://github.com/PostHog/posthog-java/pull/29 but I've reworked it to have tests and adding the addition of client side generated uuids. The user is experiencing missing events, so to handle intermittent connection issues or service availability we retry on IO issues, as well as 5xx errors. We do not retry on 400 errors, or successes.
