### PR TITLE
chore(ci): update to jdk 17

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v2
 
-      - name: Set up JDK 8
+      - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 17
 
       - name: Cache Maven packages
         uses: actions/cache@v2

--- a/posthog/pom.xml
+++ b/posthog/pom.xml
@@ -32,8 +32,8 @@
   </scm>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/posthog/src/main/java/com/posthog/java/HttpSender.java
+++ b/posthog/src/main/java/com/posthog/java/HttpSender.java
@@ -13,9 +13,9 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 
 public class HttpSender implements Sender {
-    private String apiKey;
-    private String host;
-    private OkHttpClient client;
+    private final String apiKey;
+    private final String host;
+    private final OkHttpClient client;
 
     public static class Builder {
         // required
@@ -70,7 +70,7 @@ public class HttpSender implements Sender {
     }
 
     private String getRequestBody(List<JSONObject> events) {
-        JSONObject jsonObject = new JSONObject();
+        var jsonObject = new JSONObject();
         try {
             jsonObject.put("api_key", apiKey);
             jsonObject.put("batch", events);

--- a/posthog/src/main/java/com/posthog/java/PostHog.java
+++ b/posthog/src/main/java/com/posthog/java/PostHog.java
@@ -8,7 +8,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 public class PostHog {
-    private QueueManager queueManager;
+    private final QueueManager queueManager;
     private Thread queueManagerThread;
 
     private static abstract class BuilderBase {
@@ -106,7 +106,7 @@ public class PostHog {
      *                          set without overwriting previous values.
      */
     public void identify(String distinctId, Map<String, Object> properties, Map<String, Object> propertiesSetOnce) {
-        Map<String, Object> props = new HashMap<String, Object>();
+        var props = new HashMap<String, Object>();
         if (properties != null) {
             props.put("$set", properties);
         }
@@ -136,7 +136,7 @@ public class PostHog {
      *                   overriden.
      */
     public void alias(String distinctId, String alias) {
-        Map<String, Object> props = new HashMap<String, Object>() {
+        var props = new HashMap<String, Object>() {
             {
                 put("distinct_id", distinctId);
                 put("alias", alias);
@@ -152,7 +152,7 @@ public class PostHog {
      * @param properties an array with any person properties you'd like to set.
      */
     public void set(String distinctId, Map<String, Object> properties) {
-        Map<String, Object> props = new HashMap<String, Object>() {
+        var props = new HashMap<String, Object>() {
             {
                 put("$set", properties);
             }
@@ -168,7 +168,7 @@ public class PostHog {
      *                   Previous values will not be overwritten.
      */
     public void setOnce(String distinctId, Map<String, Object> properties) {
-        Map<String, Object> props = new HashMap<String, Object>() {
+        var props = new HashMap<String, Object>() {
             {
                 put("$set_once", properties);
             }
@@ -177,7 +177,7 @@ public class PostHog {
     }
 
     private JSONObject getEventJson(String event, String distinctId, Map<String, Object> properties) {
-        JSONObject eventJson = new JSONObject();
+        var eventJson = new JSONObject();
         try {
             eventJson.put("timestamp", Instant.now().toString());
             eventJson.put("distinct_id", distinctId);

--- a/posthog/src/main/java/com/posthog/java/QueueManager.java
+++ b/posthog/src/main/java/com/posthog/java/QueueManager.java
@@ -9,14 +9,14 @@ import java.util.List;
 import org.json.JSONObject;
 
 public class QueueManager implements Runnable {
-    class QueuePtr {
+    static class QueuePtr {
         // TODO: not sure if there's a datastructure in Java that gives me these
         // operations efficiently, specifically retrieveAndReset
         // Not sure if LinkedList and JSONObject are good choices here
-        public List<JSONObject> ptr = new LinkedList<JSONObject>();
+        public List<JSONObject> ptr = new LinkedList<>();
 
         public QueuePtr() {
-        };
+        }
 
         public synchronized int size() {
             return ptr.size();
@@ -35,19 +35,19 @@ public class QueueManager implements Runnable {
                 return Collections.emptyList();
             }
             List<JSONObject> cur = ptr;
-            ptr = new LinkedList<JSONObject>();
+            ptr = new LinkedList<>();
             return cur;
         }
     }
 
-    private QueuePtr queue = new QueuePtr();
+    private final QueuePtr queue = new QueuePtr();
     private volatile boolean stop = false;
     private Instant sendAfter;
     // builder inputs
-    private Sender sender;
-    private int maxQueueSize;
-    private Duration maxTimeInQueue;
-    private int sleepMs;
+    private final Sender sender;
+    private final int maxQueueSize;
+    private final Duration maxTimeInQueue;
+    private final int sleepMs;
 
     public static class Builder {
         // required
@@ -102,7 +102,7 @@ public class QueueManager implements Runnable {
     }
 
     public void sendAll() {
-        List<JSONObject> toSend = queue.retrieveAndReset();
+        var toSend = queue.retrieveAndReset();
         updateSendAfter(); // after queue reset but before sending as the latter could take a long time
         if (!toSend.isEmpty()) {
             sender.send(toSend);

--- a/posthog/src/main/java/com/posthog/java/Sender.java
+++ b/posthog/src/main/java/com/posthog/java/Sender.java
@@ -5,5 +5,5 @@ import java.util.List;
 import org.json.JSONObject;
 
 public interface Sender {
-    public void send(List<JSONObject> events);
+    void send(List<JSONObject> events);
 }

--- a/posthog/src/test/java/com/posthog/java/HttpSenderTest.java
+++ b/posthog/src/test/java/com/posthog/java/HttpSenderTest.java
@@ -97,9 +97,9 @@ public class HttpSenderTest {
         assertEquals(success, true);
 
         // Now verify that we only
-        RecordedRequest firstRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
+        var firstRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
         assertEquals(firstRequest.getPath(), "/batch");
-        RecordedRequest secondRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
+        var secondRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
         assertEquals(secondRequest, null);
     }
 
@@ -115,9 +115,9 @@ public class HttpSenderTest {
         assertEquals(success, false);
 
         // Now verify that we only
-        RecordedRequest firstRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
+        var firstRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
         assertEquals(firstRequest.getPath(), "/batch");
-        RecordedRequest secondRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
+        var secondRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
         assertEquals(secondRequest, null);
     }
 
@@ -133,9 +133,9 @@ public class HttpSenderTest {
         assertEquals(success, false);
 
         // Verify we made two requests
-        RecordedRequest firstRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
+        var firstRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
         assertEquals(firstRequest.getPath(), "/batch");
-        RecordedRequest secondRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
+        var secondRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
         assertEquals(secondRequest.getPath(), "/batch");
     }
 }

--- a/posthog/src/test/java/com/posthog/java/HttpSenderTest.java
+++ b/posthog/src/test/java/com/posthog/java/HttpSenderTest.java
@@ -15,21 +15,20 @@ import org.junit.Test;
 
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
 
 public class HttpSenderTest {
 
     public MockWebServer mockWebServer;
     private HttpSender sender;
-    private String apiKey = "UNIT_TESTING_API_KEY";
 
     @Before
     public void setUp() throws IOException {
         mockWebServer = new MockWebServer();
         mockWebServer.start();
 
-        String httpUrl = mockWebServer.url("").toString();
-        String host = httpUrl.substring(0, httpUrl.length() - 1); // strip trailing /
+        var httpUrl = mockWebServer.url("").toString();
+        var host = httpUrl.substring(0, httpUrl.length() - 1); // strip trailing /
+        var apiKey = "UNIT_TESTING_API_KEY";
         sender = new HttpSender.Builder(apiKey).host(host).build();
     }
 
@@ -46,11 +45,11 @@ public class HttpSenderTest {
     @Test
     public void testOneItem() throws InterruptedException {
         mockWebServer.enqueue(new MockResponse());
-        JSONObject json = new JSONObject("{'key': 'value'}");
-        List<JSONObject> input = new ArrayList<JSONObject>();
+        var json = new JSONObject("{'key': 'value'}");
+        var input = new ArrayList<JSONObject>();
         input.add(json);
         sender.send(input);
-        RecordedRequest request = mockWebServer.takeRequest();
+        var request = mockWebServer.takeRequest();
         assertEquals("/batch", request.getPath());
         assertThatJson("{\"api_key\":\"UNIT_TESTING_API_KEY\",\"batch\":[{\"key\":\"value\"}]}")
                 .isEqualTo(request.getBody().readUtf8());
@@ -59,15 +58,15 @@ public class HttpSenderTest {
     @Test
     public void testMultipleItems() throws InterruptedException {
         mockWebServer.enqueue(new MockResponse());
-        JSONObject json = new JSONObject("{'key': 'value'}");
-        JSONObject json2 = new JSONObject("{'key2': 'value2'}");
-        JSONObject json3 = new JSONObject("{'key3': 'value3'}");
+        var json = new JSONObject("{'key': 'value'}");
+        var json2 = new JSONObject("{'key2': 'value2'}");
+        var json3 = new JSONObject("{'key3': 'value3'}");
         List<JSONObject> input = new ArrayList<JSONObject>();
         input.add(json);
         input.add(json2);
         input.add(json3);
         sender.send(input);
-        RecordedRequest request = mockWebServer.takeRequest();
+        var request = mockWebServer.takeRequest();
         assertEquals("/batch", request.getPath());
         assertThatJson("{\"api_key\":\"UNIT_TESTING_API_KEY\",\"batch\":"
                 + "[{\"key\":\"value\"},{\"key2\":\"value2\"},{\"key3\":\"value3\"}]}")

--- a/posthog/src/test/java/com/posthog/java/PostHogTest.java
+++ b/posthog/src/test/java/com/posthog/java/PostHogTest.java
@@ -209,6 +209,7 @@ public class PostHogTest {
     // NOTE: this test doesn't appear to pass when run with the rest of the
     // tests, but does pass when run individually. I'm disabling for now to get
     // CI green.
+    @Ignore
     @Test
     public void testMaxTimeInQueue() throws InterruptedException {
         queueManager = new QueueManager.Builder(sender).sleepMs(0).maxTimeInQueue(Duration.ofDays(3))

--- a/posthog/src/test/java/com/posthog/java/PostHogTest.java
+++ b/posthog/src/test/java/com/posthog/java/PostHogTest.java
@@ -10,6 +10,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.HashMap;
 
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/posthog/src/test/java/com/posthog/java/PostHogTest.java
+++ b/posthog/src/test/java/com/posthog/java/PostHogTest.java
@@ -209,7 +209,6 @@ public class PostHogTest {
     // NOTE: this test doesn't appear to pass when run with the rest of the
     // tests, but does pass when run individually. I'm disabling for now to get
     // CI green.
-    @Ignore
     @Test
     public void testMaxTimeInQueue() throws InterruptedException {
         queueManager = new QueueManager.Builder(sender).sleepMs(0).maxTimeInQueue(Duration.ofDays(3))

--- a/posthog/src/test/java/com/posthog/java/PostHogTest.java
+++ b/posthog/src/test/java/com/posthog/java/PostHogTest.java
@@ -9,7 +9,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.HashMap;
 
-import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -52,7 +51,7 @@ public class PostHogTest {
         ph.shutdown();
         assertEquals(1, sender.calls.size());
         assertEquals(1, sender.calls.get(0).size());
-        JSONObject json = sender.calls.get(0).get(0);
+        var json = sender.calls.get(0).get(0);
         assertThatJson(
                 "{\"distinct_id\":\"test id\",\"event\":\"test event\",\"timestamp\":\"" + instantExpected + "\"}")
                 .isEqualTo(json.toString());
@@ -60,7 +59,7 @@ public class PostHogTest {
 
     @Test
     public void testCaptureWithProperties() {
-        ph.capture("test id", "test event", new HashMap<String, Object>() {
+        ph.capture("test id", "test event", new HashMap<>() {
             {
                 put("movie_id", 123);
                 put("category", "romcom");
@@ -69,7 +68,7 @@ public class PostHogTest {
         ph.shutdown();
         assertEquals(1, sender.calls.size());
         assertEquals(1, sender.calls.get(0).size());
-        JSONObject json = sender.calls.get(0).get(0);
+        var json = sender.calls.get(0).get(0);
         assertThatJson("{\"distinct_id\":\"test id\",\"event\":\"test event\""
                 + ",\"properties\":{\"movie_id\":123,\"category\":\"romcom\"},\"timestamp\":\"" + instantExpected
                 + "\"}").isEqualTo(json.toString());
@@ -77,7 +76,7 @@ public class PostHogTest {
 
     @Test
     public void testIdentifySimple() {
-        ph.identify("test id", new HashMap<String, Object>() {
+        ph.identify("test id", new HashMap<>() {
             {
                 put("email", "john@doe.com");
                 put("proUser", false);
@@ -86,7 +85,7 @@ public class PostHogTest {
         ph.shutdown();
         assertEquals(1, sender.calls.size());
         assertEquals(1, sender.calls.get(0).size());
-        JSONObject json = sender.calls.get(0).get(0);
+        var json = sender.calls.get(0).get(0);
         assertThatJson("{\"distinct_id\":\"test id\",\"event\":\"$identify\""
                 + ",\"properties\":{\"$set\":{\"email\":\"john@doe.com\",\"proUser\":false}},\"timestamp\":\""
                 + instantExpected + "\"}").isEqualTo(json.toString());
@@ -94,12 +93,12 @@ public class PostHogTest {
 
     @Test
     public void testIdentifyWithSetOnce() {
-        ph.identify("test id", new HashMap<String, Object>() {
+        ph.identify("test id", new HashMap<>() {
             {
                 put("email", "john@doe.com");
                 put("proUser", false);
             }
-        }, new HashMap<String, Object>() {
+        }, new HashMap<>() {
             {
                 put("first_location", "colorado");
                 put("first_number", 5);
@@ -108,7 +107,7 @@ public class PostHogTest {
         ph.shutdown();
         assertEquals(1, sender.calls.size());
         assertEquals(1, sender.calls.get(0).size());
-        JSONObject json = sender.calls.get(0).get(0);
+        var json = sender.calls.get(0).get(0);
         assertThatJson("{\"distinct_id\":\"test id\",\"event\":\"$identify\""
                 + ",\"properties\":{\"$set\":{\"email\":\"john@doe.com\",\"proUser\":false}"
                 + ",\"$set_once\":{\"first_location\":\"colorado\",\"first_number\":5}" + "},\"timestamp\":\""
@@ -117,7 +116,7 @@ public class PostHogTest {
 
     @Test
     public void testSet() {
-        ph.set("test id", new HashMap<String, Object>() {
+        ph.set("test id", new HashMap<>() {
             {
                 put("email", "john@doe.com");
                 put("proUser", false);
@@ -126,7 +125,7 @@ public class PostHogTest {
         ph.shutdown();
         assertEquals(1, sender.calls.size());
         assertEquals(1, sender.calls.get(0).size());
-        JSONObject json = sender.calls.get(0).get(0);
+        var json = sender.calls.get(0).get(0);
         assertThatJson("{\"distinct_id\":\"test id\",\"event\":\"$set\""
                 + ",\"properties\":{\"$set\":{\"email\":\"john@doe.com\",\"proUser\":false}},\"timestamp\":\""
                 + instantExpected + "\"}").isEqualTo(json.toString());
@@ -134,7 +133,7 @@ public class PostHogTest {
 
     @Test
     public void testSetOnce() {
-        ph.setOnce("test id", new HashMap<String, Object>() {
+        ph.setOnce("test id", new HashMap<>() {
             {
                 put("first_location", "colorado");
                 put("first_number", 5);
@@ -143,7 +142,7 @@ public class PostHogTest {
         ph.shutdown();
         assertEquals(1, sender.calls.size());
         assertEquals(1, sender.calls.get(0).size());
-        JSONObject json = sender.calls.get(0).get(0);
+        var json = sender.calls.get(0).get(0);
         assertThatJson("{\"distinct_id\":\"test id\",\"event\":\"$set_once\""
                 + ",\"properties\":{\"$set_once\":{\"first_location\":\"colorado\",\"first_number\":5}"
                 + "},\"timestamp\":\"" + instantExpected + "\"}").isEqualTo(json.toString());
@@ -155,7 +154,7 @@ public class PostHogTest {
         ph.shutdown();
         assertEquals(1, sender.calls.size());
         assertEquals(1, sender.calls.get(0).size());
-        JSONObject json = sender.calls.get(0).get(0);
+        var json = sender.calls.get(0).get(0);
         assertThatJson("{\"distinct_id\":\"test id\",\"event\":\"$create_alias\""
                 + ",\"properties\":{\"distinct_id\":\"test id\",\"alias\":\"second id\"}" + ",\"timestamp\":\""
                 + instantExpected + "\"}").isEqualTo(json.toString());
@@ -188,7 +187,7 @@ public class PostHogTest {
         assertEquals(2, sender.calls.size());
         assertEquals(3, sender.calls.get(0).size());
         assertEquals(1, sender.calls.get(1).size());
-        JSONObject json = sender.calls.get(0).get(0);
+        var json = sender.calls.get(0).get(0);
         assertThatJson(
                 "{\"distinct_id\":\"id1\",\"event\":\"first batch event\",\"timestamp\":\"" + instantExpected + "\"}")
                 .isEqualTo(json.toString());
@@ -215,9 +214,9 @@ public class PostHogTest {
         queueManager = new QueueManager.Builder(sender).sleepMs(0).maxTimeInQueue(Duration.ofDays(3))
                 .maxQueueSize(10000).build();
         ph = new PostHog.BuilderWithCustomQueueManager(queueManager).build();
-        String originalInstant = "2020-02-02T02:02:02Z";
-        String secondInstant = "2020-02-03T02:02:02Z";
-        String thirdInstant = "2020-02-09T02:02:02Z";
+        var originalInstant = "2020-02-02T02:02:02Z";
+        var secondInstant = "2020-02-03T02:02:02Z";
+        var thirdInstant = "2020-02-09T02:02:02Z";
         updateInstantNow(originalInstant);
         ph.capture("id1", "first batch event");
         updateInstantNow(secondInstant);
@@ -229,7 +228,7 @@ public class PostHogTest {
         assertEquals(2, sender.calls.size());
         assertEquals(2, sender.calls.get(0).size());
         assertEquals(1, sender.calls.get(1).size());
-        JSONObject json = sender.calls.get(0).get(0);
+        var json = sender.calls.get(0).get(0);
         assertThatJson(
                 "{\"distinct_id\":\"id1\",\"event\":\"first batch event\",\"timestamp\":\"" + originalInstant + "\"}")
                 .isEqualTo(json.toString());

--- a/posthog/src/test/java/com/posthog/java/TestSender.java
+++ b/posthog/src/test/java/com/posthog/java/TestSender.java
@@ -7,7 +7,7 @@ import org.json.JSONObject;
 
 public class TestSender implements Sender {
 
-    public List<List<JSONObject>> calls = new ArrayList<List<JSONObject>>();
+    public List<List<JSONObject>> calls = new ArrayList<>();
 
     TestSender() {
     }


### PR DESCRIPTION
Java 8 is an LTS version but it's pretty old now (released 2014)

Java 17 is the current LTS... You can still run the library in Java 8 even if we're writing it with Java 17