### PR TITLE
Revert "chore(ci): update to jdk 17"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,10 +22,10 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v3
 
-      - name: Set up JDK
+      - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 8
           distribution: 'adopt'
           server-id: ossrh
           server-username: MAVEN_USERNAME

--- a/posthog/pom.xml
+++ b/posthog/pom.xml
@@ -32,8 +32,8 @@
   </scm>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/posthog/src/main/java/com/posthog/java/HttpSender.java
+++ b/posthog/src/main/java/com/posthog/java/HttpSender.java
@@ -15,9 +15,9 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 
 public class HttpSender implements Sender {
-    private final String apiKey;
-    private final String host;
-    private final OkHttpClient client;
+    private String apiKey;
+    private String host;
+    private OkHttpClient client;
     private int maxRetries;
     private Duration initialRetryInterval;
 
@@ -140,7 +140,7 @@ public class HttpSender implements Sender {
     }
 
     private String getRequestBody(List<JSONObject> events) {
-        var jsonObject = new JSONObject();
+        JSONObject jsonObject = new JSONObject();
         try {
             jsonObject.put("api_key", apiKey);
             jsonObject.put("batch", events);

--- a/posthog/src/main/java/com/posthog/java/PostHog.java
+++ b/posthog/src/main/java/com/posthog/java/PostHog.java
@@ -9,7 +9,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 public class PostHog {
-    private final QueueManager queueManager;
+    private QueueManager queueManager;
     private Thread queueManagerThread;
 
     private static abstract class BuilderBase {
@@ -107,7 +107,7 @@ public class PostHog {
      *                          set without overwriting previous values.
      */
     public void identify(String distinctId, Map<String, Object> properties, Map<String, Object> propertiesSetOnce) {
-        var props = new HashMap<String, Object>();
+        Map<String, Object> props = new HashMap<String, Object>();
         if (properties != null) {
             props.put("$set", properties);
         }
@@ -137,7 +137,7 @@ public class PostHog {
      *                   overriden.
      */
     public void alias(String distinctId, String alias) {
-        var props = new HashMap<String, Object>() {
+        Map<String, Object> props = new HashMap<String, Object>() {
             {
                 put("distinct_id", distinctId);
                 put("alias", alias);
@@ -153,7 +153,7 @@ public class PostHog {
      * @param properties an array with any person properties you'd like to set.
      */
     public void set(String distinctId, Map<String, Object> properties) {
-        var props = new HashMap<String, Object>() {
+        Map<String, Object> props = new HashMap<String, Object>() {
             {
                 put("$set", properties);
             }
@@ -169,7 +169,7 @@ public class PostHog {
      *                   Previous values will not be overwritten.
      */
     public void setOnce(String distinctId, Map<String, Object> properties) {
-        var props = new HashMap<String, Object>() {
+        Map<String, Object> props = new HashMap<String, Object>() {
             {
                 put("$set_once", properties);
             }
@@ -178,7 +178,7 @@ public class PostHog {
     }
 
     private JSONObject getEventJson(String event, String distinctId, Map<String, Object> properties) {
-        var eventJson = new JSONObject();
+        JSONObject eventJson = new JSONObject();
         try {
             // Ensure that we generate an identifier for this event such that we can e.g.
             // deduplicate server-side any duplicates we may receive.

--- a/posthog/src/main/java/com/posthog/java/QueueManager.java
+++ b/posthog/src/main/java/com/posthog/java/QueueManager.java
@@ -9,14 +9,14 @@ import java.util.List;
 import org.json.JSONObject;
 
 public class QueueManager implements Runnable {
-    static class QueuePtr {
+    class QueuePtr {
         // TODO: not sure if there's a datastructure in Java that gives me these
         // operations efficiently, specifically retrieveAndReset
         // Not sure if LinkedList and JSONObject are good choices here
-        public List<JSONObject> ptr = new LinkedList<>();
+        public List<JSONObject> ptr = new LinkedList<JSONObject>();
 
         public QueuePtr() {
-        }
+        };
 
         public synchronized int size() {
             return ptr.size();
@@ -35,19 +35,19 @@ public class QueueManager implements Runnable {
                 return Collections.emptyList();
             }
             List<JSONObject> cur = ptr;
-            ptr = new LinkedList<>();
+            ptr = new LinkedList<JSONObject>();
             return cur;
         }
     }
 
-    private final QueuePtr queue = new QueuePtr();
+    private QueuePtr queue = new QueuePtr();
     private volatile boolean stop = false;
     private Instant sendAfter;
     // builder inputs
-    private final Sender sender;
-    private final int maxQueueSize;
-    private final Duration maxTimeInQueue;
-    private final int sleepMs;
+    private Sender sender;
+    private int maxQueueSize;
+    private Duration maxTimeInQueue;
+    private int sleepMs;
 
     public static class Builder {
         // required
@@ -102,7 +102,7 @@ public class QueueManager implements Runnable {
     }
 
     public void sendAll() {
-        var toSend = queue.retrieveAndReset();
+        List<JSONObject> toSend = queue.retrieveAndReset();
         updateSendAfter(); // after queue reset but before sending as the latter could take a long time
         if (!toSend.isEmpty()) {
             sender.send(toSend);

--- a/posthog/src/test/java/com/posthog/java/HttpSenderTest.java
+++ b/posthog/src/test/java/com/posthog/java/HttpSenderTest.java
@@ -16,20 +16,21 @@ import org.junit.Test;
 
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
 public class HttpSenderTest {
 
     public MockWebServer mockWebServer;
     private HttpSender sender;
+    private String apiKey = "UNIT_TESTING_API_KEY";
 
     @Before
     public void setUp() throws IOException {
         mockWebServer = new MockWebServer();
         mockWebServer.start();
 
-        var httpUrl = mockWebServer.url("").toString();
-        var host = httpUrl.substring(0, httpUrl.length() - 1); // strip trailing /
-        var apiKey = "UNIT_TESTING_API_KEY";
+        String httpUrl = mockWebServer.url("").toString();
+        String host = httpUrl.substring(0, httpUrl.length() - 1); // strip trailing /
         sender = new HttpSender.Builder(apiKey).host(host).maxRetries(1).build();
     }
 
@@ -46,11 +47,11 @@ public class HttpSenderTest {
     @Test
     public void testOneItem() throws InterruptedException {
         mockWebServer.enqueue(new MockResponse());
-        var json = new JSONObject("{'key': 'value'}");
-        var input = new ArrayList<JSONObject>();
+        JSONObject json = new JSONObject("{'key': 'value'}");
+        List<JSONObject> input = new ArrayList<JSONObject>();
         input.add(json);
         sender.send(input);
-        var request = mockWebServer.takeRequest();
+        RecordedRequest request = mockWebServer.takeRequest();
         assertEquals("/batch", request.getPath());
         assertThatJson("{\"api_key\":\"UNIT_TESTING_API_KEY\",\"batch\":[{\"key\":\"value\"}]}")
                 .isEqualTo(request.getBody().readUtf8());
@@ -59,15 +60,15 @@ public class HttpSenderTest {
     @Test
     public void testMultipleItems() throws InterruptedException {
         mockWebServer.enqueue(new MockResponse());
-        var json = new JSONObject("{'key': 'value'}");
-        var json2 = new JSONObject("{'key2': 'value2'}");
-        var json3 = new JSONObject("{'key3': 'value3'}");
+        JSONObject json = new JSONObject("{'key': 'value'}");
+        JSONObject json2 = new JSONObject("{'key2': 'value2'}");
+        JSONObject json3 = new JSONObject("{'key3': 'value3'}");
         List<JSONObject> input = new ArrayList<JSONObject>();
         input.add(json);
         input.add(json2);
         input.add(json3);
         sender.send(input);
-        var request = mockWebServer.takeRequest();
+        RecordedRequest request = mockWebServer.takeRequest();
         assertEquals("/batch", request.getPath());
         assertThatJson("{\"api_key\":\"UNIT_TESTING_API_KEY\",\"batch\":"
                 + "[{\"key\":\"value\"},{\"key2\":\"value2\"},{\"key3\":\"value3\"}]}")
@@ -97,9 +98,9 @@ public class HttpSenderTest {
         assertEquals(success, true);
 
         // Now verify that we only
-        var firstRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
+        RecordedRequest firstRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
         assertEquals(firstRequest.getPath(), "/batch");
-        var secondRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
+        RecordedRequest secondRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
         assertEquals(secondRequest, null);
     }
 
@@ -115,9 +116,9 @@ public class HttpSenderTest {
         assertEquals(success, false);
 
         // Now verify that we only
-        var firstRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
+        RecordedRequest firstRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
         assertEquals(firstRequest.getPath(), "/batch");
-        var secondRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
+        RecordedRequest secondRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
         assertEquals(secondRequest, null);
     }
 
@@ -133,9 +134,9 @@ public class HttpSenderTest {
         assertEquals(success, false);
 
         // Verify we made two requests
-        var firstRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
+        RecordedRequest firstRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
         assertEquals(firstRequest.getPath(), "/batch");
-        var secondRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
+        RecordedRequest secondRequest = mockWebServer.takeRequest(0, TimeUnit.MILLISECONDS);
         assertEquals(secondRequest.getPath(), "/batch");
     }
 }

--- a/posthog/src/test/java/com/posthog/java/PostHogTest.java
+++ b/posthog/src/test/java/com/posthog/java/PostHogTest.java
@@ -53,7 +53,7 @@ public class PostHogTest {
         ph.shutdown();
         assertEquals(1, sender.calls.size());
         assertEquals(1, sender.calls.get(0).size());
-        var json = sender.calls.get(0).get(0);
+        JSONObject json = sender.calls.get(0).get(0);
         // Assert JSON includes the expected distinct_id, event, and timestamp, ignoring
         // any extraneus properties.
         assertThatJson("{\"distinct_id\":\"test id\",\"event\":\"test event\",\"timestamp\":\"" + instantExpected
@@ -85,7 +85,7 @@ public class PostHogTest {
 
     @Test
     public void testCaptureWithProperties() {
-        ph.capture("test id", "test event", new HashMap<>() {
+        ph.capture("test id", "test event", new HashMap<String, Object>() {
             {
                 put("movie_id", 123);
                 put("category", "romcom");
@@ -94,7 +94,7 @@ public class PostHogTest {
         ph.shutdown();
         assertEquals(1, sender.calls.size());
         assertEquals(1, sender.calls.get(0).size());
-        var json = sender.calls.get(0).get(0);
+        JSONObject json = sender.calls.get(0).get(0);
         assertThatJson("{\"distinct_id\":\"test id\",\"event\":\"test event\""
                 + ",\"properties\":{\"movie_id\":123,\"category\":\"romcom\"},\"timestamp\":\"" + instantExpected
                 + "\"}").isEqualTo(new JSONObject(json, "distinct_id", "event", "properties", "timestamp").toString());
@@ -102,7 +102,7 @@ public class PostHogTest {
 
     @Test
     public void testIdentifySimple() {
-        ph.identify("test id", new HashMap<>() {
+        ph.identify("test id", new HashMap<String, Object>() {
             {
                 put("email", "john@doe.com");
                 put("proUser", false);
@@ -111,7 +111,7 @@ public class PostHogTest {
         ph.shutdown();
         assertEquals(1, sender.calls.size());
         assertEquals(1, sender.calls.get(0).size());
-        var json = sender.calls.get(0).get(0);
+        JSONObject json = sender.calls.get(0).get(0);
         assertThatJson("{\"distinct_id\":\"test id\",\"event\":\"$identify\""
                 + ",\"properties\":{\"$set\":{\"email\":\"john@doe.com\",\"proUser\":false}},\"timestamp\":\""
                 + instantExpected + "\"}")
@@ -120,12 +120,12 @@ public class PostHogTest {
 
     @Test
     public void testIdentifyWithSetOnce() {
-        ph.identify("test id", new HashMap<>() {
+        ph.identify("test id", new HashMap<String, Object>() {
             {
                 put("email", "john@doe.com");
                 put("proUser", false);
             }
-        }, new HashMap<>() {
+        }, new HashMap<String, Object>() {
             {
                 put("first_location", "colorado");
                 put("first_number", 5);
@@ -134,7 +134,7 @@ public class PostHogTest {
         ph.shutdown();
         assertEquals(1, sender.calls.size());
         assertEquals(1, sender.calls.get(0).size());
-        var json = sender.calls.get(0).get(0);
+        JSONObject json = sender.calls.get(0).get(0);
         assertThatJson("{\"distinct_id\":\"test id\",\"event\":\"$identify\""
                 + ",\"properties\":{\"$set\":{\"email\":\"john@doe.com\",\"proUser\":false}"
                 + ",\"$set_once\":{\"first_location\":\"colorado\",\"first_number\":5}" + "},\"timestamp\":\""
@@ -145,7 +145,7 @@ public class PostHogTest {
 
     @Test
     public void testSet() {
-        ph.set("test id", new HashMap<>() {
+        ph.set("test id", new HashMap<String, Object>() {
             {
                 put("email", "john@doe.com");
                 put("proUser", false);
@@ -154,7 +154,7 @@ public class PostHogTest {
         ph.shutdown();
         assertEquals(1, sender.calls.size());
         assertEquals(1, sender.calls.get(0).size());
-        var json = sender.calls.get(0).get(0);
+        JSONObject json = sender.calls.get(0).get(0);
         assertThatJson("{\"distinct_id\":\"test id\",\"event\":\"$set\""
                 + ",\"properties\":{\"$set\":{\"email\":\"john@doe.com\",\"proUser\":false}},\"timestamp\":\""
                 + instantExpected + "\"}")
@@ -163,7 +163,7 @@ public class PostHogTest {
 
     @Test
     public void testSetOnce() {
-        ph.setOnce("test id", new HashMap<>() {
+        ph.setOnce("test id", new HashMap<String, Object>() {
             {
                 put("first_location", "colorado");
                 put("first_number", 5);
@@ -172,7 +172,7 @@ public class PostHogTest {
         ph.shutdown();
         assertEquals(1, sender.calls.size());
         assertEquals(1, sender.calls.get(0).size());
-        var json = sender.calls.get(0).get(0);
+        JSONObject json = sender.calls.get(0).get(0);
         assertThatJson("{\"distinct_id\":\"test id\",\"event\":\"$set_once\""
                 + ",\"properties\":{\"$set_once\":{\"first_location\":\"colorado\",\"first_number\":5}"
                 + "},\"timestamp\":\"" + instantExpected + "\"}")
@@ -185,7 +185,7 @@ public class PostHogTest {
         ph.shutdown();
         assertEquals(1, sender.calls.size());
         assertEquals(1, sender.calls.get(0).size());
-        var json = sender.calls.get(0).get(0);
+        JSONObject json = sender.calls.get(0).get(0);
         assertThatJson("{\"distinct_id\":\"test id\",\"event\":\"$create_alias\""
                 + ",\"properties\":{\"distinct_id\":\"test id\",\"alias\":\"second id\"}" + ",\"timestamp\":\""
                 + instantExpected + "\"}")
@@ -219,7 +219,7 @@ public class PostHogTest {
         assertEquals(2, sender.calls.size());
         assertEquals(3, sender.calls.get(0).size());
         assertEquals(1, sender.calls.get(1).size());
-        var json = sender.calls.get(0).get(0);
+        JSONObject json = sender.calls.get(0).get(0);
         assertThatJson(
                 "{\"distinct_id\":\"id1\",\"event\":\"first batch event\",\"timestamp\":\"" + instantExpected + "\"}")
                 .isEqualTo(new JSONObject(json, "distinct_id", "event", "timestamp").toString());
@@ -246,9 +246,9 @@ public class PostHogTest {
         queueManager = new QueueManager.Builder(sender).sleepMs(0).maxTimeInQueue(Duration.ofDays(3))
                 .maxQueueSize(10000).build();
         ph = new PostHog.BuilderWithCustomQueueManager(queueManager).build();
-        var originalInstant = "2020-02-02T02:02:02Z";
-        var secondInstant = "2020-02-03T02:02:02Z";
-        var thirdInstant = "2020-02-09T02:02:02Z";
+        String originalInstant = "2020-02-02T02:02:02Z";
+        String secondInstant = "2020-02-03T02:02:02Z";
+        String thirdInstant = "2020-02-09T02:02:02Z";
         updateInstantNow(originalInstant);
         ph.capture("id1", "first batch event");
         updateInstantNow(secondInstant);
@@ -260,7 +260,7 @@ public class PostHogTest {
         assertEquals(2, sender.calls.size());
         assertEquals(2, sender.calls.get(0).size());
         assertEquals(1, sender.calls.get(1).size());
-        var json = sender.calls.get(0).get(0);
+        JSONObject json = sender.calls.get(0).get(0);
         assertThatJson(
                 "{\"distinct_id\":\"id1\",\"event\":\"first batch event\",\"timestamp\":\"" + originalInstant + "\"}")
                 .isEqualTo(new JSONObject(json, "distinct_id", "event", "timestamp").toString());

--- a/posthog/src/test/java/com/posthog/java/TestSender.java
+++ b/posthog/src/test/java/com/posthog/java/TestSender.java
@@ -7,7 +7,7 @@ import org.json.JSONObject;
 
 public class TestSender implements Sender {
 
-    public List<List<JSONObject>> calls = new ArrayList<>();
+    public List<List<JSONObject>> calls = new ArrayList<List<JSONObject>>();
 
     TestSender() {
     }


### PR DESCRIPTION
Reverts PostHog/posthog-java#34

I think I'd got my brain backwards. Compiling with Java 17 means Java 8 can't run it (for example)

Whereas compiling for Java 8 still allows Java 17 to run it.