### PR TITLE
fix: include posthog library property in events

### DIFF
--- a/posthog/src/main/java/com/posthog/java/PostHog.java
+++ b/posthog/src/main/java/com/posthog/java/PostHog.java
@@ -191,6 +191,7 @@ public class PostHog {
             eventJson.put("timestamp", Instant.now().toString());
             eventJson.put("distinct_id", distinctId);
             eventJson.put("event", event);
+            eventJson.put("$lib", "posthog-java");
             if (properties != null) {
                 eventJson.put("properties", properties);
             }

--- a/posthog/src/test/java/com/posthog/java/PostHogTest.java
+++ b/posthog/src/test/java/com/posthog/java/PostHogTest.java
@@ -101,6 +101,21 @@ public class PostHogTest {
     }
 
     @Test
+    public void testCaptureIncludesLibProperty() {
+        ph.capture("test id", "test event", new HashMap<String, Object>() {
+            {
+                put("movie_id", 123);
+                put("category", "romcom");
+            }
+        });
+        ph.shutdown();
+        assertEquals(1, sender.calls.size());
+        assertEquals(1, sender.calls.get(0).size());
+        JSONObject json = sender.calls.get(0).get(0);
+        assertThatJson("{\"$lib\":\"posthog-java\"}").isEqualTo(new JSONObject(json, "$lib").toString());
+    }
+
+    @Test
     public void testIdentifySimple() {
         ph.identify("test id", new HashMap<String, Object>() {
             {


### PR DESCRIPTION
we don't include $lib

well, we do now!

closes #39 